### PR TITLE
Avoid deserialization of string to get IChatBaseComponent

### DIFF
--- a/src/main/java/eu/greev/jumpandrun/utils/Output.java
+++ b/src/main/java/eu/greev/jumpandrun/utils/Output.java
@@ -2,6 +2,7 @@ package eu.greev.jumpandrun.utils;
 
 import org.bukkit.entity.Player;
 
+import net.minecraft.server.v1_8_R3.ChatMessage;
 import net.minecraft.server.v1_8_R3.IChatBaseComponent;
 import net.minecraft.server.v1_8_R3.PacketPlayOutChat;
 import net.minecraft.server.v1_8_R3.PacketPlayOutTitle;
@@ -13,14 +14,14 @@ public class Output {
     }
 
     public static void sendActionBar(Player p, String msg) {
-        IChatBaseComponent cbc = IChatBaseComponent.ChatSerializer.a("{\"text\": \"" + msg + "\"}");
+        IChatBaseComponent cbc = new ChatMessage(msg);
         PacketPlayOutChat ppoc = new PacketPlayOutChat(cbc, (byte) 2);
         ((CraftPlayer) p).getHandle().playerConnection.sendPacket(ppoc);
     }
 
     public static void sendTitle(Player p, String text, String sbtext) {
-        IChatBaseComponent chatTitle = IChatBaseComponent.ChatSerializer.a("{text:\"§6" + text + "\"}");
-        IChatBaseComponent chatSubtitle = IChatBaseComponent.ChatSerializer.a("{text:\"" + sbtext + "\"}");
+        IChatBaseComponent chatTitle = new ChatMessage("§6" + text);
+        IChatBaseComponent chatSubtitle = new ChatMessage(sbtext);
         PacketPlayOutTitle packetPlayOutTimes = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.TIMES, null, 10, 60, 10);
         PacketPlayOutTitle packetPlayOutTitle = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.TITLE, chatTitle);
         PacketPlayOutTitle packetPlayOutSubtitle = new PacketPlayOutTitle(PacketPlayOutTitle.EnumTitleAction.SUBTITLE, chatSubtitle);


### PR DESCRIPTION
The easiest and most efficient way is to create an IChatBaseComponent object is to do so by hand instead of letting the deserializer create it from a string.
This method also has another neat benefit: It does not break when using special characters inside of the string as they don't need to be safe for JSON.